### PR TITLE
Fix Flaky Test When calling different parse to input of csv

### DIFF
--- a/src/main/java/com/univocity/parsers/common/fields/FieldConversionMapping.java
+++ b/src/main/java/com/univocity/parsers/common/fields/FieldConversionMapping.java
@@ -94,7 +94,7 @@ public class FieldConversionMapping implements Cloneable {
 
 		//Note this property is shared across all conversion mappings. This is required so
 		//the correct conversion sequence is registered for all fields.
-		conversionsByIndex = new HashMap<Integer, List<Conversion<?, ?>>>();
+		conversionsByIndex = new LinkedHashMap<Integer, List<Conversion<?, ?>>>();
 
 		// adds the conversions in the sequence they were created.
 		for (FieldSelector next : conversionSequence) {


### PR DESCRIPTION
Trying to Solve: 
When calling nonDex test on com.univocity.parsers.common.processor.AnnotatedBeanProcessorTest#testAnnotatedBeanProcessor, in some seeds, the test will throw errors at line92 when trying to parse input CSV to target format. For example, it might throw that calling trim parser for "True". This is because the order of values in the field of CSV is changed and can't match its parser when calling apply conversion. Instead of using LinkedHashMap, we can ensure the order of field and parse remains the same.